### PR TITLE
Update Code icon from lightning bolt to file

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -90,7 +90,7 @@
       </li>
       <li>
         <a href="{{ url_for("airflow.code", dag_id=dag.dag_id, root=root) }}">
-          <span class="glyphicon glyphicon-flash" aria-hidden="true"></span>
+          <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
           Code
         </a>
       </li>


### PR DESCRIPTION
Lightning bolts are not a visual metaphor for code or files. Since Glyphicon doesn't have a code icon (<>, for instance), we should use its file icon.

Dear Airflow Maintainers,

Please accept this PR that addresses the following issues:
- AIRFLOW-906

Testing Done:
- None.

Before/After screenshots in AIRFLOW-906 (https://issues.apache.org/jira/browse/AIRFLOW-906)

